### PR TITLE
Add instructions for additional OS X configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ functionality.
 
 * [Kaleidoscope-HostOS](https://github.com/keyboardio/Kaleidoscope-HostOS)
 
+## Other Configuration
+
+On OS X/macOS, you'll need to change the input method to be "Unicode Hex Input".
+You can do this by going to System Preferences > Keyboard > Input Sources, clicking
+the `+` button, selecting it from the list, then setting it as the active input method.
+
 ## Further reading
 
 Starting from the [example][plugin:example] is the recommended way of getting


### PR DESCRIPTION
The library types unicode characters on OS X by holding down left Alt + numbers, which only works if the Unicode Hex Input source is active.