### PR TITLE
Make the example more complete

### DIFF
--- a/examples/Unicode/Unicode.ino
+++ b/examples/Unicode/Unicode.ino
@@ -21,7 +21,12 @@
 #include <Kaleidoscope.h>
 #include <Kaleidoscope-HostOS.h>
 #include <Kaleidoscope/HostOS-select.h>
+#include "Kaleidoscope-Macros.h"
 #include <Kaleidoscope-Unicode.h>
+
+enum { MACRO_KEYBOARD_EMOJI };
+
+// *INDENT-OFF*
 
 const Key keymaps[][ROWS][COLS] PROGMEM = {
   [0] = KEYMAP_STACKED
@@ -29,26 +34,41 @@ const Key keymaps[][ROWS][COLS] PROGMEM = {
     Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
     Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
     Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
-    Key_PageDown,   Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+    Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
 
     Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
     Key_skip,
 
-    Key_skip,  Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
-    Key_Enter, Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
-    Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
-    Key_skip,  Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+    M(MACRO_KEYBOARD_EMOJI), Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
+    Key_Enter,               Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
+                             Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
+    Key_skip,                Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
 
     Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
     Key_skip),
 };
 
+// *INDENT-ON*
+
+static void unicode(uint32_t character, uint8_t keyState) {
+  if (keyToggledOn(keyState)) {
+    Unicode.type(character);
+  }
+}
+
+const macro_t *macroAction(uint8_t macroIndex, uint8_t keyState) {
+  switch (macroIndex) {
+  case MACRO_KEYBOARD_EMOJI:
+    unicode(0x2328, keyState);
+    break;
+  }
+  return MACRO_NONE;
+}
+
 void setup() {
-  Kaleidoscope.use(&Unicode);
+  Kaleidoscope.use(&Macros, &Unicode);
 
   Kaleidoscope.setup();
-
-  Unicode.type(0x2328);
 }
 
 void loop() {


### PR DESCRIPTION
Instead of the example being as minimalistic as possible, show how you can make a key type a unicode character.

Context: https://community.keyboard.io/t/unicode-plugin-feedback-macros-feedback-how-to-fix-infinite-typing/747

**Note:** I have _not_ tested this example. But I did copy parts from my own layout.

If this PR is not the correct approach, please see it as an issue report instead, about it not being straight-forward for a beginner how to use this plugin.